### PR TITLE
add support for instantiation object

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,4 +1,8 @@
 
+### 1.0.2 - 2017-09-07
+
+- if an object is passed in, populate the notes with it
+
 ### 1.0.1 - 2017-09-04
 
 - initial release

--- a/index.js
+++ b/index.js
@@ -1,8 +1,12 @@
-'use strict';
+'use strict'
 
 class Notes {
 
-    constructor () {
+    constructor (notes) {
+
+        if (notes && typeof notes === 'object') {
+            Object.assign(this, notes)
+        }
 
         Object.defineProperty(this, 'set', {
             configurable: false,
@@ -41,12 +45,12 @@ class Notes {
     }
 }
 
-module.exports = Notes;
+module.exports = Notes
 
 function getSegments (path) {
     // a dot.delimited.path
-    if (typeof path === 'string') return path.split('.');
+    if (typeof path === 'string') return path.split('.')
 
     // ['one', 'two', 'thr.ee']
-    if (Array.isArray(path)) return path;
+    if (Array.isArray(path)) return path
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-notes",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Haraka Notes",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -6,71 +6,85 @@ const Notes  = require('../index')
 describe('notes', () => {
 
     beforeEach((done) => {
-        this.notes = new Notes();
-        done();
-    });
+        this.notes = new Notes()
+        done()
+    })
 
     it('exports an object', (done) => {
-        // console.log(this.notes);
-        assert.ok(typeof this.notes === 'object');
-        done();
-    });
+        // console.log(this.notes)
+        assert.ok(typeof this.notes === 'object')
+        done()
+    })
 
-    const functionList = ['get', 'set'];
+    const functionList = ['get', 'set']
 
     functionList.forEach((fn) => {
         it(`has ${fn}()`, (done) => {
-            assert.equal(typeof this.notes[fn], 'function');
-            done();
+            assert.equal(typeof this.notes[fn], 'function')
+            done()
         })
     })
 
     functionList.forEach((fn) => {
         it(`ignores attempts to redefine ${fn}`, (done) => {
-            this.notes[fn] = 'turd';
-            this.notes[fn]('turd');
-            done();
-        });
+            this.notes[fn] = 'turd'
+            this.notes[fn]('turd')
+            done()
+        })
     })
 
     it('sets a top level value', (done) => {
-        this.notes.set('foo', 'bar');
-        // console.log(this.notes);
-        assert.equal(this.notes.foo, 'bar');
-        done();
-    });
+        this.notes.set('foo', 'bar')
+        // console.log(this.notes)
+        assert.equal(this.notes.foo, 'bar')
+        done()
+    })
 
     it('gets a top level value', (done) => {
-        this.notes.set('foo', 'bar');
-        assert.equal(this.notes.get('foo'), 'bar');
-        done();
-    });
+        this.notes.set('foo', 'bar')
+        assert.equal(this.notes.get('foo'), 'bar')
+        done()
+    })
 
     it('sets/gets a second level value', (done) => {
-        this.notes.set('seg1.seg2', 'bar');
-        assert.equal(this.notes.seg1.seg2, 'bar');
-        assert.equal(this.notes.get('seg1.seg2'), 'bar');
-        done();
-    });
+        this.notes.set('seg1.seg2', 'bar')
+        assert.equal(this.notes.seg1.seg2, 'bar')
+        assert.equal(this.notes.get('seg1.seg2'), 'bar')
+        done()
+    })
 
     it('sets/gets a three level value', (done) => {
-        this.notes.set('one.two.three', 'floor');
-        assert.equal(this.notes.one.two.three, 'floor');
-        assert.equal(this.notes.get('one.two.three'), 'floor');
-        done();
-    });
+        this.notes.set('one.two.three', 'floor')
+        assert.equal(this.notes.one.two.three, 'floor')
+        assert.equal(this.notes.get('one.two.three'), 'floor')
+        done()
+    })
 
     it('supports array syntax', (done) => {
-        this.notes.set(['one', 'two', 'three'], 'floor');
-        assert.equal(this.notes.one.two.three, 'floor');
-        assert.equal(this.notes.get(['one', 'two', 'three']), 'floor');
-        done();
-    });
+        this.notes.set(['one', 'two', 'three'], 'floor')
+        assert.equal(this.notes.one.two.three, 'floor')
+        assert.equal(this.notes.get(['one', 'two', 'three']), 'floor')
+        done()
+    })
 
     it('array syntax tolerates dots', (done) => {
-        this.notes.set(['one', 'two', 'three.four'], 'floor');
-        assert.equal(this.notes.one.two['three.four'], 'floor');
-        assert.equal(this.notes.get(['one', 'two', 'three.four']), 'floor');
-        done();
-    });
+        this.notes.set(['one', 'two', 'three.four'], 'floor')
+        assert.equal(this.notes.one.two['three.four'], 'floor')
+        assert.equal(this.notes.get(['one', 'two', 'three.four']), 'floor')
+        done()
+    })
+})
+
+describe('notes + object', () => {
+
+    it('assigns instantiation object', (done) => {
+        let passIn = {
+            one: true,
+            two: "false",
+            three: "floor",
+        }
+        this.notes = this.notes = new Notes(passIn)
+        assert.deepEqual(this.notes, passIn)
+        done()
+    })
 })


### PR DESCRIPTION
and join the comma free society

This support a soon-to-land Haraka PR, because in outbound, the notes makes a trip through JSON.parse and loses the get/set functions. This will enable restoring them.